### PR TITLE
2020年と間違えたため再度テスト

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,11 +2,10 @@
 const http = require('http');
 const server = http.createServer((req, res) => {
   const now = Date.now();
-  res.setHeader('Set-Cookie', 'last_access=' + now + ';');
+  res.setHeader('Set-Cookie', 'last_access=' + now + ';expires=Mon, 07 Jan 2036 00:00:00 GMT;');
   res.end(req.headers.cookie);
 });
 const port = 8000;
 server.listen(port, () => {
   console.info('Listening on ' + port);
 });
-


### PR DESCRIPTION
nnn-training/intro-curriculum-3018をforkしたらintro-curriculum-3019になった！？
>ラベネコ先生より
①まずは intro-curriculum-3019 にいく
② URLの末尾を 3019から3018に変更してアクセス
③ Settingsをクリック
④ 一番下までスクロールして、 Delete this repository をクリック
⑤ Please type {ユーザ名}/intro-curriculum-3018 to confirm. の  {ユーザ名}/intro-curriculum-3018 の部分をコピーして下に貼り付け
⑥ I understand〜〜 のボタンを押す
⑦ これで intro-curriculum-3018が消えました。同様にintro-curriculum-3019、intro-curriculum-3020 を消します。
⑧ intro-curriculum-3018 intro-curriculum-3019 intro-curriculum-3020 をもう一度フォークしてください