### PR TITLE
Cookie の有効期限を2036年1月7日に設定

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,21 @@
 'use strict';
 const http = require('http');
 const server = http.createServer((req, res) => {
+  console.log(req.method, req.url);
+  if (req.url === '/favicon.ico') {
+    return res.end();
+  }
   const now = Date.now();
-  res.setHeader('Set-Cookie', 'last_access=' + now + ';');
+  // Cookieの有効期限を2036年1月7日に設定
+  const expiresDate = 'Mon, 07 Jan 2036 00:00:00 GMT';
+
+  // Cookieの有効期限を現在から30日後に設定 (2022年度版の練習問題)
+  // const expiresDate = new Date(now + 30 * 24 * 60 * 60 * 1000).toUTCString();
+
+  console.log({now});
+  console.log({expiresDate});
+
+  res.setHeader('Set-Cookie', `last_access=${now};expires=${expiresDate};`);
   res.end(req.headers.cookie);
 });
 const port = 8000;


### PR DESCRIPTION
2022年8月2日より、Google Chrome v104 から、Cookie の最長有効期間が400日になったので実際は設定できていないです。
実装した日が2022年10月19日なので、`2023-11-22T15:20:55.503Z` が設定されました。
https://developer.chrome.com/blog/new-in-chrome-104/